### PR TITLE
Translated "Installation" page & "In this chapter" block's label

### DIFF
--- a/src/components/MDX/MDXComponents.tsx
+++ b/src/components/MDX/MDXComponents.tsx
@@ -173,7 +173,7 @@ function YouWillLearn({
   children: any;
   isChapter?: boolean;
 }) {
-  let title = isChapter ? 'In this chapter' : 'You will learn';
+  let title = isChapter ? 'In questo capitolo' : 'Imparerai';
   return <SimpleCallout title={title}>{children}</SimpleCallout>;
 }
 

--- a/src/content/learn/installation.md
+++ b/src/content/learn/installation.md
@@ -10,8 +10,8 @@ React è stato progettato sin dal principio per essere adottato gradualmente. A 
 
 <YouWillLearn isChapter={true}>
 
-* [How to start a new React project](/learn/start-a-new-react-project)
-* [How to add React to an existing project](/learn/add-react-to-an-existing-project)
+* [Come iniziare un nuovo progetto React](/learn/start-a-new-react-project)
+* [Come aggiungere React ad un progetto esistente](/learn/add-react-to-an-existing-project)
 * [Come configurare il tuo editor](/learn/editor-setup)
 * [Come installare i React Developer Tools](/learn/react-developer-tools)
 
@@ -43,10 +43,10 @@ La maggioranza delle pagine della documentazione di React contengono sandboxes c
 
 Per provare React localmente sul suo computer, [scarica questa pagina HTML.](https://gist.githubusercontent.com/gaearon/0275b1e1518599bbeafcde4722e79ed1/raw/db72dcbf3384ee1708c4a07d3be79860db04bff0/example.html) Aprila nel tuo editor e nel tuo browser!
 
-## Start a new React project {/*start-a-new-react-project*/}
+## Inizia un nuovo progetto React {/*start-a-new-react-project*/}
 
-If you want to build an app or a website fully with React, [start a new React project.](/learn/start-a-new-react-project)
+Se desideri creare un'app o un sito web completamente con React, [inizia un nuovo progetto React.](/learn/start-a-new-react-project)
 
-## Add React to an existing project {/*add-react-to-an-existing-project*/}
+## Aggiungi React ad un progetto esistente {/*add-react-to-an-existing-project*/}
 
-If want to try using React in your existing app or a website, [add React to an existing project.](/learn/add-react-to-an-existing-project)
+Se desideri provare ad utilizzare React nella tua app o in un sito web esistente, [aggiungi React ad un progetto esistente.](/learn/add-react-to-an-existing-project)

--- a/src/sidebarLearn.json
+++ b/src/sidebarLearn.json
@@ -21,19 +21,19 @@
       ]
     },
     {
-      "title": "Installation",
+      "title": "Installazione",
       "path": "/learn/installation",
       "routes": [
         {
-          "title": "Start a New React Project",
+          "title": "Inizia un nuovo progetto React",
           "path": "/learn/start-a-new-react-project"
         },
         {
-          "title": "Add React to an Existing Project",
+          "title": "Aggiungi React ad un progetto esistente",
           "path": "/learn/add-react-to-an-existing-project"
         },
         {
-          "title": "Editor Setup",
+          "title": "Setup dell'editor",
           "path": "/learn/editor-setup"
         },
         {


### PR DESCRIPTION
Added translations for _"Installation"_ page and updated translations for the _"In this chapter"_ code block.

See [#418](https://github.com/reactjs/it.react.dev/issues/418)
