### PR TITLE
translate(sidebar-home): add missing title translations

### DIFF
--- a/src/sidebarHome.json
+++ b/src/sidebarHome.json
@@ -11,7 +11,7 @@
       "path": "/learn"
     },
     {
-      "title": "Installation",
+      "title": "Installazione",
       "path": "/learn/installation"
     },
     {
@@ -19,7 +19,7 @@
       "sectionHeader": "LEARN REACT"
     },
     {
-      "title": "Describing the UI",
+      "title": "Descrivere la UI",
       "path": "/learn/describing-the-ui"
     },
     {


### PR DESCRIPTION
### Motivation

Generally on desktop you won't see it, but on a smaller viewport the homepage renders `sidebarHome.json`.
Currently it's missing the translations for **Installation** and **Describing the UI** pages, which are instead translated in `sidebarLearn.json`

We'll have to remember this for the future 😃


### Current behaviour

<img src="https://user-images.githubusercontent.com/6226131/235424532-4997bb89-48f6-458c-9a0b-a40d1266223e.png"  height="500px" />